### PR TITLE
Python 3.x compatability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ Operating System :: Unix
 Programming Language :: Python :: 2.5
 Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
+Programming Language :: Python :: 3.2
+Programming Language :: Python :: 3.3
 Topic :: Desktop Environment :: K Desktop Environment (KDE)
 Topic :: Software Development
 Topic :: Software Development :: Quality Assurance
@@ -22,7 +24,7 @@ setup(
     name='pyprof2calltree',
     version=version,
     description="Help visualize profiling data from cProfile with kcachegrind",
-    long_description=file('README.txt').read(),
+    long_description=open('README.txt').read(),
     keywords='profiler visualization programming tool kde kcachegrind',
     classifiers=[c for c in classifiers.split("\n") if c and c.strip()],
     author='Olivier Grisel',


### PR DESCRIPTION
I made some small modifications to make `pyprof2calltree` run on Python 3.x.

These are:
- using `list(dct.items())` instead of `dct.items()` in places proposed by the `2to3` script. (Same for `dct.values()`)
- replacing `print >> out_file, 'string` with `out_file.write('string\n')`
- replacing `print 'string'` with `sys.stdout.write('string\n')` (as suggested in the [Python 3 Porting Guide](http://docs.pythonsprints.com/python3_porting/py-porting.html#printing))
- replacing `file(fn)` with `open(fn)`
- replacing `file(fn, mode)` with `open(fn, mode)`
- replacing `isinstance(foo, basestring)` with a call to a helper function `is_basestring(foo)`:
  
  ``` python
  def is_basestring(s):
      try:
          u = unicode
          # Python 2.x
          return isinstance(s, basestring)
      except NameError:
          # Python 3.x
          return isinstance(s, (str, bytes))
  ```

With these changes, I was able to install and use `pyprof2calltree` on Python 3.3 (by means of using the `@profile` decorator from [`profilestats`](https://github.com/hannosch/profilestats) on a simple function). I checked that it (still) works on all the Python versions declared in the trove classifiers, which are:
- `Programming Language :: Python :: 2.5`
- `Programming Language :: Python :: 2.6`
- `Programming Language :: Python :: 2.7`
- `Programming Language :: Python :: 3.2`
- `Programming Language :: Python :: 3.3`
