### PR TITLE
Don't output fi= and cfi= lines

### DIFF
--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -158,7 +158,6 @@ class CalltreeConverter(object):
         code = entry.code
 
         co_filename, co_firstlineno, co_name = cProfile.label(code)
-        out_file.write('fi=%s\n' % (co_filename,))
         if co_filename != '~' and co_firstlineno != 0:
             out_file.write('fn=%s %s:%d\n' % (
                 co_name, co_filename, co_firstlineno))
@@ -189,9 +188,7 @@ class CalltreeConverter(object):
     def _subentry(self, lineno, subentry, call_info):
         out_file = self.out_file
         code = subentry.code
-        # out_file.write('cob=%s\n' % (code.co_filename,))
         co_filename, co_firstlineno, co_name = cProfile.label(code)
-        out_file.write('cfi=%s\n' % (co_filename,))
         if co_filename != '~' and co_firstlineno != 0:
             out_file.write('cfn=%s %s:%d\n' % (
                 co_name, co_filename, co_firstlineno))


### PR DESCRIPTION
The `fi=` and `cfi=` lines are making the call graph much less easy to follow. As far as I can tell, they don't provide any additional useful information anyway.

``` python
# source for /tmp/foo.py
import time

def func2():
    time.sleep(0.5)

def func1():
    time.sleep(0.5)
    for i in range(2):
        func2()

def main():
    time.sleep(0.5)
    func1()
    for i in range(3):
        func2()

main()
```

Running the profile:

```
python -m cProfile -o /tmp/foo.profile /tmp/foo.py
pyprof2calltree -i /tmp/foo.profile /tmp/foo.log
qcachegrind /tmp/foo.log
```

qcachegrind before this change (notice the duplicate entries and lack of complete graph):

![image](https://f.cloud.github.com/assets/150329/1570129/7905a5d6-50e3-11e3-9e4c-2e8c35b8d78e.png)

qcachegrind after this change:

![image](https://f.cloud.github.com/assets/150329/1570121/5713f02c-50e3-11e3-9d7d-bf20d9c58523.png)
