### PR TITLE
Python 3 compatibility (pyprof2calltree.py)

### DIFF
--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -287,7 +287,7 @@ def main():
         # user either explicitly required output file or requested by not
         # explicitly asking to launch kcachegrind
         sys.stderr.write("writing converted data to: %s\n" % outfile)
-        kg.output(open(outfile, 'wb'))
+        kg.output(open(outfile, 'w'))
 
     if options.kcachegrind:
         sys.stderr.write("launching kcachegrind\n")


### PR DESCRIPTION
Fixes the following exception when converting Python profiling data to the callgrind format:

```
Traceback (most recent call last):
  File "pyprof2calltree", line 9, in <module>
    load_entry_point('pyprof2calltree==1.3.0', 'console_scripts', 'pyprof2calltree')()
  File "pyprof2calltree.py", line 290, in main
    kg.output(open(outfile, 'wb'))
  File "pyprof2calltree.py", line 130, in output
    out_file.write('events: Ticks\n')
TypeError: 'str' does not support the buffer interface
```
