### PR TITLE
Python 3 compatibility (pyprof2calltree.py)

### DIFF
--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -141,7 +141,7 @@ class CalltreeConverter(object):
 
         if self.out_file is None:
             _, outfile = tempfile.mkstemp(".log", "pyprof2calltree")
-            f = open(outfile, "wb")
+            f = open(outfile, "w")
             self.output(f)
             use_temp_file = True
         else:
@@ -319,7 +319,7 @@ def convert(profiling_data, outputfile):
     """
     converter = CalltreeConverter(profiling_data)
     if is_basestring(outputfile):
-        f = open(outputfile, "wb")
+        f = open(outputfile, "w")
         try:
             converter.output(f)
         finally:


### PR DESCRIPTION
In #8, I have missed few more instances of the same kind of problem: strings are saved to a file, which is opened as a binary stream. I'm sorry about that.
