### PR TITLE
Name de-duplication, change units, and add some tests

### DIFF
--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -113,8 +113,11 @@ def pstats2entries(data):
         for entry_caller, call_info in entry_callers:
             subentry = Subentry()
             subentry.code = entry.code
-            subentry.callcount, subentry.reccallcount, subentry.inlinetime, \
-                subentry.totaltime = call_info
+            cc, nc, tt, ct = call_info
+            subentry.callcount = cc
+            subentry.reccallcount = nc - cc
+            subentry.inlinetime = tt
+            subentry.totaltime = ct
             entries[entry_caller].calls.append(subentry)
 
     return list(entries.values())

--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -213,6 +213,9 @@ class CalltreeConverter(object):
         for entry in self.entries:
             totaltime = int(entry.totaltime * 1000)
             max_cost = max(max_cost, totaltime)
+        # Version 0.7.4 of kcachegrind appears to ignore the summary line and
+        # calculate the total cost by summing the exclusive cost of all
+        # functions, but it doesn't hurt to output it anyway.
         self.out_file.write('summary: %d\n' % (max_cost,))
 
     def _entry(self, entry):

--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -45,6 +45,8 @@ from collections import defaultdict
 
 __all__ = ['convert', 'visualize', 'CalltreeConverter']
 
+SCALE = 1e9
+
 class Code(object):
     def __repr__(self):
         return '<Code: %s, %s, %s>' % (self.co_filename, self.co_firstlineno,
@@ -166,7 +168,8 @@ class CalltreeConverter(object):
     def output(self, out_file):
         """Write the converted entries to out_file"""
         self.out_file = out_file
-        out_file.write('events: Ticks\n')
+        out_file.write('event: ns : Nanoseconds\n')
+        out_file.write('events: ns\n')
         self._print_summary()
         for entry in self.entries:
             self._entry(entry)
@@ -211,7 +214,7 @@ class CalltreeConverter(object):
     def _print_summary(self):
         max_cost = 0
         for entry in self.entries:
-            totaltime = int(entry.totaltime * 1000)
+            totaltime = int(entry.totaltime * SCALE)
             max_cost = max(max_cost, totaltime)
         # Version 0.7.4 of kcachegrind appears to ignore the summary line and
         # calculate the total cost by summing the exclusive cost of all
@@ -232,7 +235,7 @@ class CalltreeConverter(object):
             assert munged_name == co_name
             out_file.write('fn=%s\n' % co_name)
 
-        inlinetime = int(entry.inlinetime * 1000)
+        inlinetime = int(entry.inlinetime * SCALE)
         if is_basestring(code):
             out_file.write('0  %s\n' % inlinetime)
         else:
@@ -247,7 +250,7 @@ class CalltreeConverter(object):
 
             for subentry in entry.calls:
                 self._subentry(lineno, subentry.code, subentry.callcount,
-                               int(subentry.totaltime * 1000))
+                               int(subentry.totaltime * SCALE))
 
         out_file.write('\n')
 

--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -44,10 +44,17 @@ import tempfile
 __all__ = ['convert', 'visualize', 'CalltreeConverter']
 
 class Code(object):
-    pass
+    def __repr__(self):
+        return '<Code: %s, %s, %s>' % (self.co_filename, self.co_firstlineno,
+                                       self.co_name)
 
 class Entry(object):
-    pass
+    def __repr__(self):
+        subentry_info = [(entry.code, info) for entry, info in self.calls]
+        return '<Entry: %s, %s, %s, %s, %s, %s>' % (
+            self.code, self.callcount, self.reccallcount, self.inlinetime,
+            self.totaltime, subentry_info
+        )
 
 def is_basestring(s):
     try:

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     license='BSD',
     py_modules = ['pyprof2calltree'],
     zip_safe=True,
+    test_suite='tests',
     entry_points = {
         'setuptools.installation': [
             'eggsecutable = pyprof2calltree:main',

--- a/tests/profile_code.py
+++ b/tests/profile_code.py
@@ -1,0 +1,126 @@
+# We're going to use a custom timer, so we don't actually have to do anything
+# in these functions.
+def top():
+    mid1()
+    mid2()
+    mid3(5)
+    C1.samename()
+    C2.samename()
+
+def mid1():
+    bot()
+    for i in range(5):
+        mid2()
+    bot()
+
+def mid2():
+    bot()
+
+def bot():
+    pass
+
+def mid3(x):
+    if x > 0:
+        mid4(x)
+
+def mid4(x):
+    mid3(x - 1)
+
+class C1(object):
+    @staticmethod
+    def samename():
+        pass
+
+class C2(object):
+    @staticmethod
+    def samename():
+        pass
+
+expected_output = """event: ns : Nanoseconds
+events: ns
+summary: 59000
+fl=<filename>
+fn=top
+3 6000
+cfl=<filename>
+cfn=mid1
+calls=1 10
+3 27000
+cfl=<filename>
+cfn=mid2
+calls=1 16
+3 3000
+cfl=<filename>
+cfn=mid3
+calls=1 22
+3 21000
+cfl=<filename>
+cfn=samename:30
+calls=1 30
+3 1000
+cfl=<filename>
+cfn=samename:35
+calls=1 35
+3 1000
+
+fl=<filename>
+fn=mid1
+10 9000
+cfl=<filename>
+cfn=mid2
+calls=5 16
+10 15000
+cfl=<filename>
+cfn=bot
+calls=2 19
+10 2000
+cfl=~
+cfn=<range>
+calls=1 0
+10 1000
+
+fl=<filename>
+fn=mid2
+16 12000
+cfl=<filename>
+cfn=bot
+calls=6 19
+16 6000
+
+fl=<filename>
+fn=bot
+19 8000
+
+fl=<filename>
+fn=mid3
+22 11000
+cfl=<filename>
+cfn=mid4
+calls=5 26
+22 19000
+
+fl=<filename>
+fn=mid4
+26 10000
+cfl=<filename>
+cfn=mid3
+calls=5 22
+26 17000
+
+fl=<filename>
+fn=samename:30
+30 1000
+
+fl=<filename>
+fn=samename:35
+35 1000
+
+fl=~
+fn=<method 'disable' of '_lsprof.Profiler' objects>
+0 1000
+
+fl=~
+fn=<range>
+0 1000
+
+""".replace('<filename>', top.__code__.co_filename)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,40 @@
+import cProfile
+import pstats
+import unittest
+
+from .profile_code import top, expected_output
+from cStringIO import StringIO
+from pyprof2calltree import CalltreeConverter
+
+class MockTimeProfile(cProfile.Profile):
+    def __init__(self):
+        self._mock_time = 0
+        super(MockTimeProfile, self).__init__(self._timer, 1e-9)
+
+    def _timer(self):
+        now = self._mock_time
+        self._mock_time += 1000
+        return now
+
+class TestIntegration(unittest.TestCase):
+    def setUp(self):
+        self.profile = MockTimeProfile()
+        self.profile.enable()
+        top()
+        self.profile.disable()
+
+    def test_direct_entries(self):
+        entries = self.profile.getstats()
+        converter = CalltreeConverter(entries)
+        out_file = StringIO()
+
+        converter.output(out_file)
+        self.assertEqual(out_file.getvalue(), expected_output)
+
+    def test_pstats_data(self):
+        stats = pstats.Stats(self.profile)
+        converter = CalltreeConverter(stats)
+        out_file = StringIO()
+
+        converter.output(out_file)
+        self.assertEqual(out_file.getvalue(), expected_output)


### PR DESCRIPTION
Major changes:
* Support multiple functions with the same name defined in the same file (such as inherited methods or inner functions)
* Change units from ticks (milliseconds) to nanoseconds. This fixes potentially large inaccuracy in time percentage calculations
* Add minimal tests

Minor changes:
* Add `__repr__` methods for easier debugging
* Fix creating callgraph profiles directly from cProfile entries
* Fix reccallcount for subentries
* Misc cleanups