### PR TITLE
tests: Fix StringIO import for Python 3

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,10 @@ import pstats
 import unittest
 
 from .profile_code import top, expected_output
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from pyprof2calltree import CalltreeConverter
 
 class MockTimeProfile(cProfile.Profile):


### PR DESCRIPTION
Python 3 no longer provides a 'cStringIO' module. Use StringIO from 'io'
module instead.