### PR TITLE
Distribute packages as a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
-[egg_info]
-#tag_build = dev
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Wheels are the standard of Python distribution and are intended to
replace eggs. Support is offered in pip >= 1.4 and setuptools >= 0.8.

Advantages of wheels

- Faster installation
- Avoids arbitrary code execution for installation by avoiding setup.py
- Allows better caching for testing and continuous integration
- Creates .pyc files as part of installation to ensure they match the Python interpreter used
- More consistent installs across platforms and machines

For additional details and information, see: https://pythonwheels.com/

Include the LICENSE file in the generated wheel package. This is done
using the [metadata] section in the setup.cfg file. For additional
information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file