### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -22,7 +22,7 @@ In chronological order:
   * Fix in conversion algorithm
 
 * Peter Waller <p@pwaller.net>
-  * Taking over pypi maintainance
+  * Taking over PyPI maintainance
 
 * Steven Maude
   * Breaking things, documentation

--- a/README.txt
+++ b/README.txt
@@ -7,7 +7,7 @@ analyser.
 
 This is a rebranding of the venerable
 http://www.gnome.org/~johan/lsprofcalltree.py script by David Allouche
-et Al. It aims at making it easier to distribute (e.g. through pypi)
+et Al. It aims at making it easier to distribute (e.g. through PyPI)
 and behave more like the scripts of the debian kcachegrind-converters_
 package. The final goal is to make it part of the official upstream
 kdesdk_ package.

--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2006-2008, David Allouche, Jp Calderone, Itamar Shtull-Trauring,
 # Johan Dahlin, Olivier Grisel <olivier.grisel@ensta.org>
 #
-# Send maintenance requests needing new pypi packages to:
+# Send maintenance requests needing new PyPI packages to:
 #   Peter Waller <p@pwaller.net>
 #   https://github.com/pwaller/pyprof2calltree
 #


### PR DESCRIPTION
As spelled on https://pypi.org/.