### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -92,4 +92,3 @@ Change log
  - 1.1.0 - 2008-12-21: integrate fix in conversion by David Glick
  - 1.0.3 - 2008-10-16: fix typos in 1.0 release
  - 1.0 - 2008-10-16: initial release under the pyprof2calltree name
-

--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -137,7 +137,7 @@ def pstats2entries(data):
 def is_installed(prog):
     """Return whether or not a given executable is installed on the machine."""
     devnull = open(os.devnull, 'w')
-    
+
     try:
         if os.name == 'nt':
             retcode = subprocess.call(['where', prog], stdout=devnull)
@@ -145,9 +145,9 @@ def is_installed(prog):
             retcode = subprocess.call(['which', prog], stdout=devnull)
     except FileNotFoundError:
         retcode = 1
-        
+
     devnull.close()
-        
+
     return retcode == 0
 
 


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.