### PR TITLE
Fix tests on Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info/
 *.pyc
+.tox/
 __pycache__/
 build/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+language: python
+cache: pip
+
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
+      dist: xenial
+      sudo: required
+
+install: pip install tox
+script: tox

--- a/test/profile_code.py
+++ b/test/profile_code.py
@@ -36,7 +36,7 @@ class C2(object):
     def samename():
         pass
 
-expected_output = """event: ns : Nanoseconds
+expected_output_py2 = """event: ns : Nanoseconds
 events: ns
 summary: 59000
 fl=<filename>
@@ -123,4 +123,85 @@ fl=~
 fn=<range>
 0 1000
 
-""".replace('<filename>', top.__code__.co_filename)
+""".replace('<filename>', __file__)
+
+expected_output_py3 = """event: ns : Nanoseconds
+events: ns
+summary: 57000
+fl=<filename>
+fn=top
+3 6000
+cfl=<filename>
+cfn=mid1
+calls=1 10
+3 25000
+cfl=<filename>
+cfn=mid2
+calls=1 16
+3 3000
+cfl=<filename>
+cfn=mid3
+calls=1 22
+3 21000
+cfl=<filename>
+cfn=samename:30
+calls=1 30
+3 1000
+cfl=<filename>
+cfn=samename:35
+calls=1 35
+3 1000
+
+fl=<filename>
+fn=mid1
+10 8000
+cfl=<filename>
+cfn=mid2
+calls=5 16
+10 15000
+cfl=<filename>
+cfn=bot
+calls=2 19
+10 2000
+
+fl=<filename>
+fn=mid2
+16 12000
+cfl=<filename>
+cfn=bot
+calls=6 19
+16 6000
+
+fl=<filename>
+fn=bot
+19 8000
+
+fl=<filename>
+fn=mid3
+22 11000
+cfl=<filename>
+cfn=mid4
+calls=5 26
+22 19000
+
+fl=<filename>
+fn=mid4
+26 10000
+cfl=<filename>
+cfn=mid3
+calls=5 22
+26 17000
+
+fl=<filename>
+fn=samename:30
+30 1000
+
+fl=<filename>
+fn=samename:35
+35 1000
+
+fl=~
+fn=<method 'disable' of '_lsprof.Profiler' objects>
+0 1000
+
+""".replace('<filename>', __file__)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,13 +1,21 @@
 import cProfile
 import pstats
+import sys
 import unittest
 
-from .profile_code import top, expected_output
+from .profile_code import top, expected_output_py2, expected_output_py3
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
 from pyprof2calltree import CalltreeConverter
+
+
+if sys.version_info < (3, 0):
+    expected_output = expected_output_py2
+else:
+    expected_output = expected_output_py3
+
 
 class MockTimeProfile(cProfile.Profile):
     def __init__(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py{27,34,35,36,37}
+
+[testenv]
+commands = python setup.py test


### PR DESCRIPTION
On Python 3, the range builtin is a generator. It is no listed as a called function. Adjust the expected outcome to take this into account.