### PR TITLE
Correct license in setuptools to MIT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     maintainer='Peter Waller',
     maintainer_email='p@pwaller.net',
     url='https://github.com/pwaller/pyprof2calltree/',
-    license='BSD',
+    license='MIT',
     py_modules = ['pyprof2calltree'],
     zip_safe=True,
     test_suite='test',


### PR DESCRIPTION
The text in `LICENSE` is the MIT license. The trove classifier is also listed as the MIT license. The `license` argument to setuptools should match.