### PR TITLE
Fix filename of compiled bytecode in Python 2 tests

### DIFF
--- a/test/profile_code.py
+++ b/test/profile_code.py
@@ -123,7 +123,7 @@ fl=~
 fn=<range>
 0 1000
 
-""".replace('<filename>', __file__)
+""".replace('<filename>', top.__code__.co_filename)
 
 expected_output_py3 = """event: ns : Nanoseconds
 events: ns


### PR DESCRIPTION
For Python 2, When the file is compiled to bytecode, the suffix of the
expected filaname changes to ".pyc". Due to this, running the test suite
on compiled bytecode fails on Python 2. This fixes a mistake introduced
in bc37aba241688815ae879b45aaefd98a141a7642.