### PR TITLE
Always delete the temporary file in visualize()

### DIFF
--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -214,17 +214,7 @@ class CalltreeConverter(object):
         must be present in the system path.
         """
 
-        if self.out_file is None:
-            fd, outfile = tempfile.mkstemp(".log", "pyprof2calltree")
-            with open(fd, "w") as f:
-                self.output(f)
-            use_temp_file = True
-        else:
-            outfile = self.out_file.name
-            use_temp_file = False
-
         available_cmd = None
-
         for cmd in KCACHEGRIND_EXECUTABLES:
             if is_installed(cmd):
                 available_cmd = cmd
@@ -235,8 +225,18 @@ class CalltreeConverter(object):
                              ", ".join(KCACHEGRIND_EXECUTABLES))
             return
 
+        if self.out_file is None:
+            fd, outfile = tempfile.mkstemp(".log", "pyprof2calltree")
+            use_temp_file = True
+        else:
+            outfile = self.out_file.name
+            use_temp_file = False
+
         try:
-            subprocess.call([cmd, outfile])
+            if use_temp_file:
+                with open(fd, "w") as f:
+                    self.output(f)
+            subprocess.call([available_cmd, outfile])
         finally:
             # clean the temporary file
             if use_temp_file:


### PR DESCRIPTION
Previously, if the function returned early due to a missing kcachegrind binary, the temporary file would not be deleted. Now:

1. Check for the kcachegrind binary exists _before_ creating a temporary file. This avoids creating the temporary file if it will not be used.
2. Wrap all of the remaining code in a try/finally to ensure the temporary file is always deleted.