### PR TITLE
Include tests, LICENSE, & CONTRIBUTORS.txt in the source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
-include pyprof2calltree.py
+include LICENSE
+include CONTRIBUTORS.txt
+recursive-include test *.py


### PR DESCRIPTION
Helps comply with own license:

> The above copyright notice and this permission notice shall be
included in all copies or substantial portions of the Software.

There is no need to explicitly include pyprof2calltree.py, that is
handled automatically by setuptools as it is listed as py_modules.

Allows running the tests from the source distribution.