### PR TITLE
Use REMAINDER for --run-script to allow passing arbitrary arguments

### DIFF
--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -298,7 +298,9 @@ def main():
                         help="Run the kcachegrind tool on the converted data",
                         action="store_true")
     parser.add_argument('-r', '--run-script',
-                        nargs='+', metavar=('scriptfile', 'args'), dest='script',
+                        nargs=argparse.REMAINDER,
+                        metavar=('scriptfile', 'args'),
+                        dest='script',
                         help="Name of the Python script to run to collect"
                         " profiling data")
     args = parser.parse_args()


### PR DESCRIPTION
Regression mistakenly introduced in f3dd542e3f50498798b7d15252adc019df67ba9e.