### PR TITLE
Fix Python 2 to open file descriptor using io.open()

### DIFF
--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -33,9 +33,12 @@ This script can either take raw cProfile.Profile.getstats() log entries or
 take a previously recorded instance of the pstats.Stats class.
 """
 
+from __future__ import unicode_literals
+
 import argparse
 import cProfile
 import errno
+import io
 import os
 import pstats
 import subprocess
@@ -234,7 +237,7 @@ class CalltreeConverter(object):
 
         try:
             if use_temp_file:
-                with open(fd, "w") as f:
+                with io.open(fd, "w") as f:
                     self.output(f)
             subprocess.call([available_cmd, outfile])
         finally:


### PR DESCRIPTION
On Python 2, open() does not support opening OS file descriptors. Use
io.open() instead which does. io.open() opens the file in text
mode (Unicode), so, use unicode_literals to always write Unicode strings
to files. This is more forward compatible with Python 3 behavior.

Fixes regression introduced in 65e48a8226ebc4b2b634d169821935c99f9cef4d.