### PR TITLE
Use metavar to restore helpful argument names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,18 +23,19 @@ Command line usage
 Upon installation you should have a `pyprof2calltree` script in your path::
 
   $ pyprof2calltree --help
-  Usage: /usr/bin/pyprof2calltree [-k] [-o output_file_path] [-i input_file_path] [-r scriptfile [args]]
+  usage: pyprof2calltree [-h] [-o output_file_path] [-i input_file_path] [-k]
+                         [-r scriptfile [args ...]]
 
-  Options:
+  optional arguments:
     -h, --help            show this help message and exit
-    -o OUTFILE, --outfile=OUTFILE
+    -o output_file_path, --outfile output_file_path
                           Save calltree stats to <outfile>
-    -i INFILE, --infile=INFILE
+    -i input_file_path, --infile input_file_path
                           Read Python stats from <infile>
-    -r SCRIPT, --run-script=SCRIPT
+    -k, --kcachegrind     Run the kcachegrind tool on the converted data
+    -r scriptfile [args ...], --run-script scriptfile [args ...]
                           Name of the Python script to run to collect profiling
                           data
-    -k, --kcachegrind     Run the kcachegrind tool on the converted data
 
 
 Python shell usage

--- a/pyprof2calltree.py
+++ b/pyprof2calltree.py
@@ -287,14 +287,15 @@ def main():
     """Execute the converter using parameters provided on the command line"""
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-o', '--outfile',
+    parser.add_argument('-o', '--outfile', metavar='output_file_path',
                         help="Save calltree stats to <outfile>")
-    parser.add_argument('-i', '--infile',
+    parser.add_argument('-i', '--infile', metavar='input_file_path',
                         help="Read Python stats from <infile>")
     parser.add_argument('-k', '--kcachegrind',
                         help="Run the kcachegrind tool on the converted data",
                         action="store_true")
-    parser.add_argument('-r', '--run-script', nargs='+', dest='script',
+    parser.add_argument('-r', '--run-script',
+                        nargs='+', metavar=('scriptfile', 'args'), dest='script',
                         help="Name of the Python script to run to collect"
                         " profiling data")
     args = parser.parse_args()


### PR DESCRIPTION
The help output changed slightly during the change from optparse to
argparse. Update text in README.rst.