### PR TITLE
Remove use of deprecated setuptools test command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     py_modules=['pyprof2calltree'],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     zip_safe=True,
-    test_suite='test',
     entry_points={
         'setuptools.installation': [
             'eggsecutable = pyprof2calltree:main',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py{27,34,35,36,37}
 
 [testenv]
-commands = python setup.py test
+commands = python -m unittest discover
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
Has been deprecated since setuptools v41.5.0 (27 Oct 2019).

https://setuptools.readthedocs.io/en/latest/setuptools.html#test-build-package-and-run-a-unittest-suite

> Warning: test is deprecated and will be removed in a future version.
> Users looking for a generic test entry point independent of test
> runner are encouraged to use tox.