### PR TITLE
Remove deprecated eggsecutable script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,6 @@ setup(
     zip_safe=True,
     test_suite='test',
     entry_points={
-        'setuptools.installation': [
-            'eggsecutable = pyprof2calltree:main',
-        ],
         'console_scripts': [
             'pyprof2calltree = pyprof2calltree:main',
         ],


### PR DESCRIPTION
Has been deprecated since setuptools v45.3.0 (07 Mar 2020).

https://setuptools.readthedocs.io/en/latest/setuptools.html#eggsecutable-scripts

> Deprecated since version 45.3.0.