### PR TITLE
Add installation instructions for Debian and derivatives.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,12 @@ kdesdk_ package.
 .. _kdesdk: http://websvn.kde.org/trunk/KDE/kdesdk/kcachegrind/converters/
 .. _screenshots: http://images.google.fr/images?q=kcachegrind
 
+Installation
+============
+
+On Debian ≥ 11, or derivatives such as Ubuntu ≥ 20.04, `sudo apt
+install kcachegrind pyprof2calltree`.
+
 Command line usage
 ==================
 


### PR DESCRIPTION
Continuing from #50, just a simple README.md update.  I imagine some users may appreciate the (to us) obvious `pip3` installation instructions, but I haven't tested via PyPI and no one should submit a PR for untested stuff ;-)