### PR TITLE
Update isort usage for isort 5.* series

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,3 @@ force_grid_wrap = 0
 include_trailing_comma = True
 line_length = 88
 multi_line_output = 3
-not_skip = __init__.py
-skip = .tox/

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,6 @@ commands = flake8
 skip_install = true
 
 [testenv:isort]
-deps = isort
-commands = isort --check-only --diff
+deps = isort >= 5.0.1
+commands = isort --check-only --diff .
 skip_install = true


### PR DESCRIPTION
- Must always pass a path
- not_skip is no longer necessary
- Now automatically skips tox directory