### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,29 @@ matrix:
       env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38
+#ppc64le support code
+    - env: TOXENV=flake8
+      arch: ppc64le
+    - env: TOXENV=isort
+      arch: ppc64le
+    - python: "2.7"
+      arch: ppc64le
+      env: TOXENV=py27
+    - python: "3.4"
+      arch: ppc64le
+      env: TOXENV=py34
+    - python: "3.5"
+      arch: ppc64le
+      env: TOXENV=py35
+    - python: "3.6"
+      arch: ppc64le
+      env: TOXENV=py36
+    - python: "3.7"
+      arch: ppc64le
+      env: TOXENV=py37
+    - python: "3.8"
+      arch: ppc64le
+      env: TOXENV=py38
 
 install: pip install tox
 script: tox


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/pyprof2calltree